### PR TITLE
🩹 Corrigido problemas com de responsividade

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -39,7 +39,7 @@ export default function RootLayout({
                             <Box
                                 maxWidth={'1920px'}
                                 w={['100%', '100%', '90%', '80%']}
-                                p={4}
+                                p={[1, 1, 2, 4]}
                             >
                                 {children}
                             </Box>


### PR DESCRIPTION
🩹 Ajustado o `padding` do conteúdo do site, como estava antes ao visualizar por uma tela menor os cards não cabiam um ao lado do outro ficando _cortado_ ou seja, para o usuário ver todo o conteúdo do card que estava ao lado direito ele tinha que _"scrollar"_ e com isso o _header_ ficava com _"pedaço"_ faltando;

Imagem de como ficou:
![image](https://github.com/user-attachments/assets/a032b171-8de6-4d50-96ec-9d5751c5f753)

`Fixed: #12 `